### PR TITLE
Change update algo to only change when needed

### DIFF
--- a/lnd.py
+++ b/lnd.py
@@ -51,13 +51,11 @@ class Lnd:
 
     def get_feereport(self):
         feereport = self.stub.FeeReport(ln.FeeReportRequest())
-        feedict={}
+        feedict = {}
         for channel_fee in feereport.channel_fees:
-            feedict[channel_fee.chan_id]={
-                    'base_fee_msat' : channel_fee.base_fee_msat,
-                    'fee_ppm' : channel_fee.fee_per_mil,
-                    }
+            feedict[channel_fee.chan_id] = (channel_fee.base_fee_msat, channel_fee.fee_per_mil)
         return feedict
+
     def get_node_info(self, nodepubkey):
         if not nodepubkey in self.node_info:
             self.node_info[nodepubkey] = self.stub.GetNodeInfo(ln.NodeInfoRequest(pub_key=nodepubkey))

--- a/matcher.py
+++ b/matcher.py
@@ -55,6 +55,24 @@ class Matcher:
 
         return Policy(self.lnd, 'default', self.default);
 
+    def current_policy(self, channel, feereport):
+        # Finds existing policy
+        current_fees=feereport[channel.chan_id]
+        current_fee_ppm = current_fees['fee_ppm']
+        current_base_fee_msat = current_fees['base_fee_msat']
+        # Is it default?
+        if int(  current_fee_ppm)        == int(  self.default.get("fee_ppm")) and \
+            float(current_base_fee_msat) == float(self.default.get("base_fee_msat")):
+            return ('default',current_fee_ppm,current_base_fee_msat)
+
+        # Is it any of the set policies?
+        for policy in self.policies:
+            if int(  current_fee_ppm)       == int(  self.config[policy].get("fee_ppm")) and \
+                float(current_base_fee_msat) == float(self.config[policy].get("base_fee_msat")):
+                return (policy,current_fee_ppm,current_base_fee_msat)
+
+        return None
+
     def eval_matchers(self, channel, policy_conf):
         map = {
             'chan'  : self.match_by_chan,

--- a/matcher.py
+++ b/matcher.py
@@ -55,24 +55,6 @@ class Matcher:
 
         return Policy(self.lnd, 'default', self.default);
 
-    def current_policy(self, channel, feereport):
-        # Finds existing policy
-        current_fees=feereport[channel.chan_id]
-        current_fee_ppm = current_fees['fee_ppm']
-        current_base_fee_msat = current_fees['base_fee_msat']
-        # Is it default?
-        if int(  current_fee_ppm)        == int(  self.default.get("fee_ppm")) and \
-            float(current_base_fee_msat) == float(self.default.get("base_fee_msat")):
-            return ('default',current_fee_ppm,current_base_fee_msat)
-
-        # Is it any of the set policies?
-        for policy in self.policies:
-            if int(  current_fee_ppm)       == int(  self.config[policy].get("fee_ppm")) and \
-                float(current_base_fee_msat) == float(self.config[policy].get("base_fee_msat")):
-                return (policy,current_fee_ppm,current_base_fee_msat)
-
-        return None
-
     def eval_matchers(self, channel, policy_conf):
         map = {
             'chan'  : self.match_by_chan,


### PR DESCRIPTION
Get current policy (name + properties)
Compare to prospective (new) policy
If ANYTHING has changed (name or any property), only then do the chan update

Dry run is now outside of the chan update.