### PR TITLE
add 'proportional' strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,22 @@ base_fee_msat = 1
 fee_ppm = 2
 ```
 
+Use proportional strategy to adjust fee rate according to channel balancedness:
+```
+[proportional]
+# 'proportional' (lower fee rate with low remote balance & higher rate with higher balance)
+# formula: fee_ppm = fee_ppm_min + remote_balance / (remote_balance + local_balance) * (fee_ppm_max - fee_ppm_min)
+chan.min_ratio = 0.2
+chan.max_ratio = 0.9
+chan.min_capacity = 1000000
+#node.min_sats = 50000000
+strategy = proportional
+base_fee_msat = 1000
+fee_ppm_min = 10
+fee_ppm_max = 200
+```
+
+
 More elaborate examples can be found in the [charge.config.example](charge.config.example) file.
 
 ### Properties
@@ -140,6 +156,7 @@ Currently available properties:
 - **cost** (calculate cost for opening channel, and set ppm to cover cost when channel depletes. properties: **cost_factor**)
 - **onchain_fee** (sets the fees to a % equivalent of a standard onchain payment of **onchain_fee_btc** BTC within **onchain_fee_numblocks** blocks.
   Requires --electrum-server to be specified. **base_fee_msat** is used if defined.)
+- **proportional** (sets fee ppm according to balancedness. properties: fee_ppm_min, fee_ppm_max)
 
 ## Contributing
 

--- a/charge.config.example
+++ b/charge.config.example
@@ -7,20 +7,17 @@ fee_ppm = 10
 # don't let charge-lnd set fees (strategy=ignore) for channels to/from the specified nodes
 node.id = 02da8d5a759ee9e4438da617cfdb61c87f723fb76c4b6371b877d0347abe953a4f,
   0266ad254117f16f16c3457e081e6207e91c5e414477a208cf4d9c633322799038
-
 strategy = ignore
 
 [expensive]
 # match channels where the peer node has set a high (>=8000 ppm) fee rate
 # and set the same fee rate on our side (strategy=match_peer)
 chan.min_fee_ppm = 8000
-
 strategy = match_peer
 
 [leafnode]
 # charge non-routing (private=true) peers a bit more for our service
 chan.private = true
-
 strategy = static
 base_fee_msat = 1000
 fee_ppm = 100
@@ -31,21 +28,37 @@ fee_ppm = 100
 node.max_sats = 1000000
 node.min_channels = 4
 node.max_channels = 8
-
 strategy = static
 base_fee_msat = 0
 fee_ppm = 1
 
-[autobalance]
+[encourage-routing]
 # 'autobalance' (lower fees so using outbound is more attractive) larger channels (min_capacity 2M sats)
 # to larger nodes (node has at least 5M sats) if balance ratio >= 0.9 (more than 90% on our side)
 chan.min_ratio = 0.9
-chan.min_capacity = 2000000
-node.min_sats = 50000000
-
+chan.min_capacity = 1000000
+#node.min_sats = 50000000
 strategy = static
-base_fee_msat = 500
-fee_ppm = 5
+base_fee_msat = 0
+fee_ppm = 1
+
+[proportional]
+chan.min_ratio = 0.2
+chan.max_ratio = 0.9
+chan.min_capacity = 1000000
+#node.min_sats = 50000000
+strategy = proportional
+base_fee_msat = 1000
+fee_ppm_min = 10
+fee_ppm_max = 200
+
+
+[discourage-routing]
+chan.max_ratio = 0.2
+chan.min_capacity = 500000
+strategy = static
+base_fee_msat = 10000
+fee_ppm = 500
 
 [pool-policy]
 # use a list of channels exported from Lightning Pool to set a policy for channels that we initiated by selling liquidity using Lightning Pool

--- a/charge.config.example
+++ b/charge.config.example
@@ -43,6 +43,8 @@ base_fee_msat = 0
 fee_ppm = 1
 
 [proportional]
+# 'proportional' (lower fee rate with low remote balance & higher rate with higher balance)
+# formula: fee_ppm = fee_ppm_min + remote_balance / (remote_balance + local_balance) * (fee_ppm_max - fee_ppm_min)
 chan.min_ratio = 0.2
 chan.max_ratio = 0.9
 chan.min_capacity = 1000000

--- a/policy.py
+++ b/policy.py
@@ -3,8 +3,10 @@ import sys
 import fmt
 from electrum import Electrum
 
+
 def debug(message):
     sys.stderr.write(message + "\n")
+
 
 class Policy:
     def __init__(self, lnd, name, config):
@@ -19,19 +21,27 @@ class Policy:
             'match_peer'  : self.strategy_match_peer,
             'cost'        : self.strategy_cost,
             'onchain_fee' : self.strategy_onchain_fee,
+            'proportional': self.strategy_proportional
         }
         strategy = self.config.get('strategy', 'ignore')
-        if not strategy in map:
+        if strategy not in map:
             debug("Unknown strategy '%s'" % strategy)
             sys.exit(1)
 
         return map[strategy](channel)
 
     def strategy_ignore(self, channel):
-        return (None,None)
+        return (None, None)
 
     def strategy_static(self, channel):
         return (self.config.getint('base_fee_msat'), self.config.getint('fee_ppm'))
+
+    def strategy_proportional(self, channel):
+        ppm_min = self.config.getint('fee_ppm_min')
+        ppm_max = self.config.getint('fee_ppm_max')
+        balance = channel.local_balance / (channel.local_balance + channel.remote_balance)
+        ppm = int(ppm_min + balance * (ppm_max - ppm_min))
+        return (self.config.getint('base_fee_msat'), ppm)
 
     def strategy_match_peer(self, channel):
         chan_info = self.lnd.get_chan_info(channel.chan_id)
@@ -41,6 +51,7 @@ class Policy:
 
     def strategy_cost(self, channel):
         chan_info = self.lnd.get_chan_info(channel.chan_id)
+        # print('chan_info:', chan_info)
         txid = chan_info.chan_point.split(':')[0]
         (block, tx, out) = fmt.lnd_to_cl_scid(channel.chan_id)
         txns = self.lnd.get_txns(start_height=block, end_height=block)
@@ -51,19 +62,19 @@ class Policy:
 
         # only take channel-open cost into account. TODO: also support coop close & force close scenarios
         if chan_open_tx is not None:
-            ppm = int(self.config.getfloat('cost_factor',1.0) * 1_000_000 * chan_open_tx.total_fees / chan_info.capacity)
+            ppm = int(self.config.getfloat('cost_factor', 1.0) * 1_000_000 * chan_open_tx.total_fees / chan_info.capacity)
         else:
-            ppm = 1 # tx not found, incoming channel, default to 1
-        return (self.config.getint('base_fee_msat'),ppm)
+            ppm = 1  # tx not found, incoming channel, default to 1
+        return (self.config.getint('base_fee_msat'), ppm)
 
     def strategy_onchain_fee(self, channel):
         if not Electrum.host or not Electrum.port:
             debug("No electrum server specified, cannot use strategy 'onchain_fee'")
             sys.exit(1)
-        numblocks = self.config.getint('onchain_fee_numblocks',6)
+        numblocks = self.config.getint('onchain_fee_numblocks', 6)
         sat_per_byte = Electrum.get_fee_estimate(numblocks)
         if sat_per_byte < 1:
-            return (None,None)
+            return (None, None)
         reference_payment = self.config.getfloat('onchain_fee_btc', 0.1)
         fee_ppm = int((0.01 / reference_payment) * (223 * sat_per_byte))
         return (self.config.getint('base_fee_msat'), fee_ppm)

--- a/policy.py
+++ b/policy.py
@@ -39,7 +39,7 @@ class Policy:
     def strategy_proportional(self, channel):
         ppm_min = self.config.getint('fee_ppm_min')
         ppm_max = self.config.getint('fee_ppm_max')
-        balance = channel.local_balance / (channel.local_balance + channel.remote_balance)
+        balance = channel.remote_balance / (channel.local_balance + channel.remote_balance)
         ppm = int(ppm_min + balance * (ppm_max - ppm_min))
         return (self.config.getint('base_fee_msat'), ppm)
 


### PR DESCRIPTION
Hi,
I added a 'proportional' strategy, meaning to adjust ppm rate depending on the current ratio of the channel.
Hopefully it can be useful to ease balancing a bit. I'll try to run it with cronjob for now, although it would really be nice to run this as daemon and react to changes in the balance.
Have a look and let me know!