### PR TITLE
Add setuptools install command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ Python and PIP should be made available on the system before installation.
 The project and its dependencies can be installed by running:
 
 ```
-$ pip install -r requirements.txt .
+$ pip install -U setuptools && pip install -r requirements.txt .
 ```
 
 On some systems using Python 3, use pip3 instead:
 
 ```
-$ pip3 install -r requirements.txt .
+$ pip3 install -U setuptools && pip3 install -r requirements.txt .
 ```
 
 When running the install as `root`, `charge-lnd` will be installed to `/usr/local/bin`. Otherwise `charge-lnd` will be installed to `$HOME/.local/bin`.


### PR DESCRIPTION
I was not able to run the install command without first installing `setuptools` for Python.

![Screenshot from 2021-03-01 18-07-34](https://user-images.githubusercontent.com/869094/109587048-3d3fda80-7abb-11eb-8bfc-21d87f260c63.png)

This change in the README may help others.