### PR TITLE
Added min_fee_ppm_delta to proportional strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Available strategies:
 |**match_peer** | sets the same base fee and fee rate values as the peer||
 |**cost** | calculate cost for opening channel, and set ppm to cover cost when channel depletes.|**base_fee_msat**<br>**cost_factor**|
 |**onchain_fee** | sets the fees to a % equivalent of a standard onchain payment (Requires --electrum-server to be specified.)| **onchain_fee_btc** BTC<br>within **onchain_fee_numblocks** blocks.<br>**base_fee_msat** is used if defined.|
-|**proportional** | sets fee ppm according to balancedness.|**base_fee_msat**<br>**min_fee_ppm**<br>**max_fee_ppm**|
+|**proportional** | sets fee ppm according to balancedness.|**base_fee_msat**<br>**min_fee_ppm**<br>**max_fee_ppm**<br>**min_fee_ppm_delta**|
 
 All strategies (except the ignore strategy) will apply the following properties if defined:
 - **min_htlc_msat**

--- a/charge.config.example
+++ b/charge.config.example
@@ -61,6 +61,7 @@ fee_ppm = 500
 [proportional]
 # 'proportional' can also be used to auto balance (lower fee rate when low remote balance & higher rate when higher remote balance)
 # fee_ppm decreases linearly with the channel balance ratio (fee_ppm_min when ratio is 1, fee_ppm_max when ratio is 0)
+# the optional min_fee_ppm_delta avoids updates that are will change less than the specified amount
 chan.min_ratio = 0.2
 chan.max_ratio = 0.9
 chan.min_capacity = 1000000
@@ -69,6 +70,7 @@ strategy = proportional
 base_fee_msat = 1000
 min_fee_ppm = 10
 max_fee_ppm = 200
+min_fee_ppm_delta = 10
 
 [pool-policy]
 # use a list of channels exported from Lightning Pool to set a policy for channels that we initiated by selling liquidity using Lightning Pool


### PR DESCRIPTION
This adds a `min_fee_ppm_delta` config option that can be used to avoid making fee updates that are negligible.

For example, if the strategy chooses between min 0 ppm and max 2000 ppm, but the calculation finds that the old value 665 ppm should be updated to 666 ppm, then this ppm delta (of 1) is very small.

If a min_fee_ppm_delta is set to 10, then this delta of 1 will be ignored. The minimum change must be 10 ppm less or 10 ppm more than the current channel ppm. This can be helpful to avoid unnecessarily frequent ppm updates if you are running the script very often but the changes are usually very small.