### PR TITLE
Fix inverted chan.min_age and chan.max_age behavior.

### DIFF
--- a/charge_lnd/matcher.py
+++ b/charge_lnd/matcher.py
@@ -173,9 +173,9 @@ class Matcher:
             return False
         (block,tx,output) = fmt.lnd_to_cl_scid(channel.chan_id)
         age = info.block_height - block
-        if 'chan.min_age' in config and not config.getint('chan.min_age') >= age:
+        if 'chan.min_age' in config and not config.getint('chan.min_age') <= age:
             return False
-        if 'chan.max_age' in config and not config.getint('chan.max_age') <= age:
+        if 'chan.max_age' in config and not config.getint('chan.max_age') >= age:
             return False
 
         return True


### PR DESCRIPTION
I just noticed that targeting channels based on their age doesn't seem to work correctly.  I'd say the behavior is inverted from what was intended, but please correct me if I'm mistaken.  

In trying to target new channels (in this example, channels that are at most 1000 blocks old), all channels older than 1000 blocks match this policy:

````
[new-channel]
chan.max_age = 1000
strategy = static
base_fee_msat = 10
fee_ppm = 1
````


On the other hand, this targets all channels newer than 1000 blocks:

````
[old-channel]
chan.min_age = 1000
strategy = static
base_fee_msat = 10
fee_ppm = 1
````


Reversing the pertinent '>' and '<' in matcher.py seems to fix this.  