### PR TITLE
Add "adjust" fee strategy and properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ Currently available properties:
 | **chan.max_remote_balance** | match on channel remote balance|# of sats|
 | **chan.min_age** | match on channel age|# of blocks|
 | **chan.max_age** | match on channel age|# of blocks|
+| **chan.min_activity** | match on most recent forward event | # of seconds|
+| **chan.max_activity** | match on most recent forward event | # of seconds|
+| **chan.min_last_update** | match when time has passed since local channel policy last updated | # of seconds |
+| **chan.max_last_update** | match when time has passed since local channel policy last updated | # of seconds |
 | **chan.min_base_fee_msat** | match on channel peer policy|# of msats|
 | **chan.max_base_fee_msat** | match on channel peer policy|# of msats|
 | **chan.min_fee_ppm** | match on channel peer policy|0..1000000 (parts per million)|
@@ -149,6 +153,7 @@ Available strategies:
 |**static** | sets fixed base fee and fee rate values.| **base_fee_msat**<br>**fee_ppm**|
 |**match_peer** | sets the same base fee and fee rate values as the peer|if **base_fee_msat** or **fee_ppm** are set the override the peer values|
 |**cost** | calculate cost for opening channel, and set ppm to cover cost when channel depletes.|**base_fee_msat**<br>**cost_factor**|
+|**adjust** | raise or lower the current fees based on a scale factor (e.x. 0.9 to lower fees 10% or 1.05 to raise 5%) | **base_fee_factor**<br>**fee_ppm_factor**|
 |**onchain_fee** | sets the fees to a % equivalent of a standard onchain payment (Requires --electrum-server to be specified.)| **onchain_fee_btc** BTC<br>within **onchain_fee_numblocks** blocks.<br>**base_fee_msat** is used if defined.|
 |**proportional** | sets fee ppm according to balancedness.|**base_fee_msat**<br>**min_fee_ppm**<br>**max_fee_ppm**|
 |**disable** | disables the channel in the outgoing direction. Channel will be re-enabled again if it matches another policy (except when that policy uses an 'ignore' strategy).||

--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ Currently available properties:
 | **chan.max_remote_balance** | match on channel remote balance|# of sats|
 | **chan.min_age** | match on channel age|# of blocks|
 | **chan.max_age** | match on channel age|# of blocks|
-| **chan.min_activity** | match on most recent forward event | # of seconds|
-| **chan.max_activity** | match on most recent forward event | # of seconds|
+| **chan.min_last_forward** | match on most recent forward event | # of seconds|
+| **chan.max_last_forward** | match on most recent forward event | # of seconds|
 | **chan.min_last_update** | match when time has passed since local channel policy last updated | # of seconds |
 | **chan.max_last_update** | match when time has passed since local channel policy last updated | # of seconds |
 | **chan.min_base_fee_msat** | match on channel peer policy|# of msats|

--- a/charge_lnd/strategy.py
+++ b/charge_lnd/strategy.py
@@ -68,6 +68,14 @@ def strategy_ignore(channel, policy, **kwargs):
 def strategy_static(channel, policy, **kwargs):
     return (policy.getint('base_fee_msat'), policy.getint('fee_ppm'))
 
+@strategy(name = 'adjust')
+def strategy_adjust(channel, policy, **kwargs):
+    lnd = kwargs['lnd']
+    chan_info = lnd.get_chan_info(channel.chan_id)
+    my_pubkey = lnd.get_own_pubkey()
+    my_policy = chan_info.node1_policy if chan_info.node1_pub == my_pubkey else chan_info.node2_policy
+    return (round(my_policy.fee_base_msat * policy.getfloat('fee_ppm_factor', 1)), round(my_policy.fee_rate_milli_msat * policy.getfloat('fee_ppm_factor', 1)))
+
 @strategy(name = 'proportional')
 def strategy_proportional(channel, policy, **kwargs):
     if policy.getint('min_fee_ppm_delta',-1) < 0:


### PR DESCRIPTION
Still testing, PR not final, looking to start discussion! Will update this message to keep current.

Adds the feature described in #15

1. Adds the `adjust` strategy with the properties `fee_ppm_factor` and `base_fee_factor` 
2. Adds the `min_last_update`, `max_last_update`, `max_last_forward`, and `max_last_forward` properties for selecting channels

Example:

```
[no-recent-activity]
# no routes in 4 days
# at least one day since updating fee policy
chan.max_last_forward = 345600 # seconds in 4 days
chan.min_last_update = 86400 # seconds in 1 day
strategy = adjust
fee_ppm_factor = 0.9 # decrease fees 10%

[popular-channel]
# at least one route in the last day
# wait at least one day before adjusting again
chan.min_last_forward = 86400
chan.min_last_update = 86400
strategy = adjust
fee_ppm_factor = 1.1 # increase fees 10%
```
