### PR TITLE
Add command parameters --tlscertpath, --macaroonpath

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -16,7 +16,7 @@ $ lncli bakemacaroon offchain:read offchain:write onchain:read info:read --save_
 
 By default charge-lnd connects to `localhost:10009`, using the macaroon file in `~/.lnd/data/chain/bitcoin/mainnet/charge-lnd.macaroon`. If `charge-lnd.macaroon` is not found, `admin.macaroon` will be tried.
 
-If you need to change these defaults, please have a look at the optional arguments `--grpc` and `--lnddir`.
+If you need to change these defaults, please have a look at the usage parameters.
 
 ## Install from source
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ usage: charge-lnd [-h] [--lnddir LNDDIR] [--grpc GRPC] [--electrum-server ELECTR
 optional arguments:
   -h, --help            show this help message and exit
   --lnddir LNDDIR       (default ~/.lnd) lnd directory
+  --tlscertpath TLS_CERT_PATH
+                        (default [lnddir]/tls.cert) path to lnd TLS certificate
+  --macaroonpath MACAROON_PATH
+                        (default [lnddir]/data/chain/bitcoin/mainnet/charge-lnd.macaroon) path to lnd auth macaroons
   --grpc GRPC           (default localhost:10009) lnd gRPC endpoint
   --electrum-server ELECTRUM_SERVER
                         (optional, no default) electrum server host:port . Needed for

--- a/charge_lnd/charge_lnd.py
+++ b/charge_lnd/charge_lnd.py
@@ -36,7 +36,7 @@ def main():
     # few systems are not utf-8, force so we don't bomb out
     sys.stdout.reconfigure(encoding='utf-8')
 
-    lnd = Lnd(arguments.lnddir, arguments.grpc)
+    lnd = Lnd(arguments.lnddir)
     if not lnd.valid:
         debug("Could not connect to gRPC endpoint")
         return False
@@ -132,6 +132,12 @@ def get_argument_parser():
                         default="~/.lnd",
                         dest="lnddir",
                         help="(default ~/.lnd) lnd directory")
+    parser.add_argument("--tlscertpath",
+                        dest="tls_cert_path",
+                        help="(default [lnddir]/tls.cert) path to lnd TLS certificate")
+    parser.add_argument("--macaroonpath",
+                        dest="macaroon_path",
+                        help="(default [lnddir]/data/chain/bitcoin/mainnet/charge-lnd.macaroon) path to lnd auth macaroon")
     parser.add_argument("--grpc",
                         default="localhost:10009",
                         dest="grpc",

--- a/charge_lnd/lnd.py
+++ b/charge_lnd/lnd.py
@@ -18,10 +18,10 @@ def debug(message):
 
 
 class Lnd:
-    def __init__(self, lnd_dir, server):
+    def __init__(self, args):
         os.environ['GRPC_SSL_CIPHER_SUITES'] = 'HIGH+ECDSA'
-        lnd_dir = expanduser(lnd_dir)
-        combined_credentials = self.get_credentials(lnd_dir)
+        lnd_dir = expanduser(args.lnd_dir)
+        combined_credentials = self.get_credentials(args)
         channel_options = [
             ('grpc.max_message_length', MESSAGE_SIZE_MB),
             ('grpc.max_receive_message_length', MESSAGE_SIZE_MB)
@@ -42,13 +42,13 @@ class Lnd:
             self.valid = False
 
     @staticmethod
-    def get_credentials(lnd_dir):
-        tls_certificate = open(lnd_dir + '/tls.cert', 'rb').read()
+    def get_credentials(args):
+        tls_certificate = open(args.tls_cert_path or lnd_dir + '/tls.cert', 'rb').read()
         ssl_credentials = grpc.ssl_channel_credentials(tls_certificate)
         try:
-            macaroon = codecs.encode(open(lnd_dir + '/data/chain/bitcoin/mainnet/charge-lnd.macaroon', 'rb').read(), 'hex')
+            macaroon = codecs.encode(open(args.macaroon_path or args.lnd_dir + '/data/chain/bitcoin/mainnet/charge-lnd.macaroon', 'rb').read(), 'hex')
         except:
-            macaroon = codecs.encode(open(lnd_dir + '/data/chain/bitcoin/mainnet/admin.macaroon', 'rb').read(), 'hex')
+            macaroon = codecs.encode(open(args.lnd_dir + '/data/chain/bitcoin/mainnet/admin.macaroon', 'rb').read(), 'hex')
         auth_credentials = grpc.metadata_call_credentials(lambda _, callback: callback([('macaroon', macaroon)], None))
         combined_credentials = grpc.composite_channel_credentials(ssl_credentials, auth_credentials)
         return combined_credentials

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,3 +1,21 @@
 #!/usr/bin/env sh
 
-exec /usr/local/bin/charge-lnd --grpc "${GRPC_LOCATION}" --lnddir "${LND_DIR}" -c "${CONFIG_LOCATION}" "$@"
+TLS_CERT_PATH=${TLS_CERT_PATH:-$LND_DIR/tls.cert}
+if [ -z "$MACAROON_PATH" ]
+then
+  exec /usr/local/bin/charge-lnd \
+    --grpc "${GRPC_LOCATION}" \
+    --lnddir "${LND_DIR}" \
+    --tlscertpath "${TLS_CERT_PATH}"
+    -c "${CONFIG_LOCATION}" \
+    "$@"
+else
+  exec /usr/local/bin/charge-lnd \
+    --grpc "${GRPC_LOCATION}" \
+    --lnddir "${LND_DIR}" \
+    --tlscertpath "${TLS_CERT_PATH}"
+    --macaroonpath "${MACAROON_PATH}"
+    -c "${CONFIG_LOCATION}" \
+    "$@"
+fi
+  


### PR DESCRIPTION
Allows to set tls cert and macaroon separately.

#57