### PR TITLE
Make docker-entrypoint.sh compatible with charge_lnd.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ usage: charge-lnd [-h] [--lnddir LNDDIR] [--grpc GRPC] [--electrum-server ELECTR
 optional arguments:
   -h, --help            show this help message and exit
   --lnddir LNDDIR       (default ~/.lnd) lnd directory
-  --tlscertpath TLS_CERT_PATH
+  --tlscert TLS_CERT_PATH
                         (default [lnddir]/tls.cert) path to lnd TLS certificate
-  --macaroonpath MACAROON_PATH
+  --macaroon MACAROON_PATH
                         (default [lnddir]/data/chain/bitcoin/mainnet/charge-lnd.macaroon) path to lnd auth macaroons
   --grpc GRPC           (default localhost:10009) lnd gRPC endpoint
   --electrum-server ELECTRUM_SERVER

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,15 +6,15 @@ then
   exec /usr/local/bin/charge-lnd \
     --grpc "${GRPC_LOCATION}" \
     --lnddir "${LND_DIR}" \
-    --tlscertpath "${TLS_CERT_PATH}"
+    --tlscert "${TLS_CERT_PATH}" \
     -c "${CONFIG_LOCATION}" \
     "$@"
 else
   exec /usr/local/bin/charge-lnd \
     --grpc "${GRPC_LOCATION}" \
     --lnddir "${LND_DIR}" \
-    --tlscertpath "${TLS_CERT_PATH}"
-    --macaroonpath "${MACAROON_PATH}"
+    --tlscert "${TLS_CERT_PATH}" \
+    --macaroon "${MACAROON_PATH}" \
     -c "${CONFIG_LOCATION}" \
     "$@"
 fi


### PR DESCRIPTION
Make docker-entrypoint.sh and README compatible with changes made in https://github.com/accumulator/charge-lnd/commit/d9f56ed5688eea07f879ed285e9ae9b1b9e5e3d3. `accumulator/charge-lnd:v0.2.9` docker image does not work and should be updated once this is merged.