### PR TITLE
Add proportional strategy flag for considering multiple channels to the same peer

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Available strategies:
 |**match_peer** | sets the same base fee and fee rate values as the peer|if **base_fee_msat** or **fee_ppm** are set the override the peer values|
 |**cost** | calculate cost for opening channel, and set ppm to cover cost when channel depletes.|**cost_factor**|
 |**onchain_fee** | sets the fees to a % equivalent of a standard onchain payment (Requires --electrum-server to be specified.)| **onchain_fee_btc** BTC<br>within **onchain_fee_numblocks** blocks.|
-|**proportional** | sets fee ppm according to balancedness.|**min_fee_ppm**<br>**max_fee_ppm**|
+|**proportional** | sets fee ppm according to balancedness.|**min_fee_ppm**<br>**max_fee_ppm**<br>**sum_peer_chans** consider all channels with peer for balance calculations|
 |**disable** | disables the channel in the outgoing direction. Channel will be re-enabled again if it matches another policy (except when that policy uses an 'ignore' strategy).||
 |**use_config** | process channel according to rules defined in another config file.|**config_file**|
 

--- a/charge_lnd/lnd.py
+++ b/charge_lnd/lnd.py
@@ -36,6 +36,7 @@ class Lnd:
         self.chan_info = {}
         self.fwdhistory = {}
         self.valid = True
+        self.peer_channels = {}
         try:
             self.feereport = self.get_feereport()
         except grpc._channel._InactiveRpcError:
@@ -180,6 +181,15 @@ class Lnd:
             request = ln.ListChannelsRequest()
             self.channels = self.stub.ListChannels(request).channels
         return self.channels
+
+    # Get all channels shared with a node
+    def get_shared_channels(self, peerid):
+        # See example: https://github.com/lightningnetwork/lnd/issues/3930#issuecomment-596041700
+        byte_peerid=bytes.fromhex(peerid)
+        if peerid not in self.peer_channels:
+            request = ln.ListChannelsRequest(peer=byte_peerid)
+            self.peer_channels[peerid] = self.stub.ListChannels(request).channels
+        return self.peer_channels[peerid]
 
     def min_version(self, major, minor, patch=0):
         p = re.compile("(\d+)\.(\d+)\.(\d+).*")

--- a/charge_lnd/policy.py
+++ b/charge_lnd/policy.py
@@ -74,6 +74,9 @@ class Policy:
     def getfloat(self, key, default=None):
         return self._get(key, float, default)
 
+    def getbool(self, key, default=None):
+        return self._get(key, bool, default)
+
     def set(self, key, value):
         self.config[key] = value
 

--- a/examples/multiple-channels-per-peer-proportional.config
+++ b/examples/multiple-channels-per-peer-proportional.config
@@ -1,0 +1,13 @@
+# all channels fees according to ratio to auto-balance,
+# also taking into consideration multiple channels per peer
+# fees are updated when fee delta >= 10
+
+[default]
+strategy = proportional
+base_fee_ppm = 1000
+min_fee_ppm = 100
+max_fee_ppm = 300
+min_fee_ppm_delta = 10
+
+# Enable special multiple channel per peer calculations
+sum_peer_chans = true


### PR DESCRIPTION
- Strategy updated for summing channels
- Lnd helper function added for getting all shared channels
- Example added
- README updated

By setting `sum_peer_chans=true` the proportional strategy will consider all channels with peer. All the active channels are summed together first. If the total is zero, then the inactive channels are summed in order to not change an offline node.

There should probably be policy additions such as `node.shared_channels`, `node.shared_capacity`, `node.shared_min_ratio`, `node.shared_max_ratio` and maybe more. This PR doesn't do any of these policy changes.