### PR TITLE
Add new properties, etc

### DIFF
--- a/charge_lnd/policy.py
+++ b/charge_lnd/policy.py
@@ -367,6 +367,8 @@ class Policies:
 
             htlcs_ratio = 0.5
             htlcs_total = fwds['htlc_in'] + fwds['htlc_out']
+            if htlcs_total == 0:
+                return False
             if htlcs_total > 0:
                 htlcs_ratio = fwds['htlc_in']/htlcs_total
             if 'chan.max_htlcs_ratio' in config and not config.getfloat('chan.max_htlcs_ratio') >= htlcs_ratio:
@@ -376,6 +378,8 @@ class Policies:
 
             sats_ratio = 0.5
             sats_total = fwds['sat_in'] + fwds['sat_out']
+            if sats_total == 0:
+                return False
             if sats_total > 0:
                 sats_ratio = fwds['sat_in']/sats_total
             if 'chan.max_sats_ratio' in config and not config.getfloat('chan.max_sats_ratio') >= sats_ratio:


### PR DESCRIPTION
1. Minor fix: `peernode.disabled` (not exist) -> `peernode_policy.disabled`
2. Add new properties. It is useful when charging fee for rebalanced channels

|Property|Description|Values|
|:--|:--|:--|
| **chan.activity_period_exact** | don't trigger if channel age less than activity_period |true\|false|
| **chan.min_htlcs_ratio** | match on amount of HTLCs ratio arriving in channel during activity period|0..1|
| **chan.max_htlcs_ratio** | match on amount of HTLCs ratio arriving in channel during activity period| 0..1|
| **chan.min_sats_ratio** | match on amount of sats ratio arriving in channel during activity period| 0..1|
| **chan.max_sats_ratio** | match on amount of sats ratio arriving in channel during activity period| 0..1|

If you are not fully agree with this pull request, Close this and consider to add `_ratio` properties at least.