### PR TITLE
Prevent format function returning int

### DIFF
--- a/charge_lnd/fmt.py
+++ b/charge_lnd/fmt.py
@@ -35,16 +35,16 @@ def print_chanid(chan_id):
     return "%sx%sx%s" % lnd_to_cl_scid(chan_id)
 
 def col_lo(s):
-    return colored(s,'white', attrs=['dark'])
+    return str(colored(s,'white', attrs=['dark']))
 
 def col_hi(s):
-    return colored(s,'white', attrs=['bold'])
+    return str(colored(s,'white', attrs=['bold']))
 
 def col_name(s):
-    return colored(s,'blue', attrs=['bold'])
+    return str(colored(s,'blue', attrs=['bold']))
 
 def col_err(s):
-    return colored(s,'red', attrs=['bold'])
+    return str(colored(s,'red', attrs=['bold']))
 
 def col_val(s):
-    return colored(s,'yellow', attrs=['bold'])
+    return str(colored(s,'yellow', attrs=['bold']))


### PR DESCRIPTION
The function `colored` returns `int` type value on specific terminal(Yes... my terminal)
So fail with below errors.
```
Traceback (most recent call last):
  File "/usr/local/bin/charge-lnd", line 5, in <module>
    from charge_lnd.charge_lnd import main
  File "/usr/local/lib/python3.7/dist-packages/charge_lnd/charge_lnd.py", line 165, in <module>
    success = main()
  File "/usr/local/lib/python3.7/dist-packages/charge_lnd/charge_lnd.py", line 119, in main
    s = ' ➜ ' + fmt.col_hi(new_max_htlc)
TypeError: can only concatenate str (not "int") to str
```

Use `str()` to prevent this.