### PR TITLE
Fix base fee entry in example config

### DIFF
--- a/examples/all-channels-proportional.config
+++ b/examples/all-channels-proportional.config
@@ -3,7 +3,7 @@
 
 [default]
 strategy = proportional
-base_fee_ppm = 1000
+base_fee_msat = 1000
 min_fee_ppm = 100
 max_fee_ppm = 300
 min_fee_ppm_delta = 10


### PR DESCRIPTION
The base_fee_ppm setting does not exist. The correct name is base_fee_msat.